### PR TITLE
[fix]buildspec.ymlの修正

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,4 +19,5 @@ phases:
 
 artifacts:
   files:
-    - "dist/*"
+    - "**/*"
+  base-directory: "dist"


### PR DESCRIPTION
S3バケット直下にindex.htmlが配置されるよう。base-directoryを追加